### PR TITLE
Sort HAR entries

### DIFF
--- a/run.go
+++ b/run.go
@@ -25,8 +25,6 @@ func Run(r *bufio.Reader) error {
 	}
 
 	for _, entry := range har.Log.Entries {
-		fmt.Printf("[%s] URL: %s\n", entry.Request.Method, entry.Request.URL)
-
 		req, err := EntryToRequest(&entry)
 
 		check(err)
@@ -36,6 +34,8 @@ func Run(r *bufio.Reader) error {
 		resp, err := client.Do(req)
 
 		check(err)
+
+		fmt.Printf("[%s,%v] URL: %s\n", entry.Request.Method, resp.StatusCode, entry.Request.URL)
 
 		if resp != nil {
 			resp.Body.Close()

--- a/run.go
+++ b/run.go
@@ -14,24 +14,24 @@ func Run(r *bufio.Reader) error {
 
 	check(err)
 
+	jar, _ := cookiejar.New(nil)
+
+	client := http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			r.URL.Opaque = r.URL.Path
+			return nil
+		},
+		Jar: jar,
+	}
+
 	for _, entry := range har.Log.Entries {
-		fmt.Printf("URL: %s\n", entry.Request.URL)
+		fmt.Printf("[%s] URL: %s\n", entry.Request.Method, entry.Request.URL)
 
 		req, err := EntryToRequest(&entry)
 
 		check(err)
 
-		jar, _ := cookiejar.New(nil)
-
 		jar.SetCookies(req.URL, req.Cookies())
-
-		client := http.Client{
-			CheckRedirect: func(r *http.Request, via []*http.Request) error {
-				r.URL.Opaque = r.URL.Path
-				return nil
-			},
-			Jar: jar,
-		}
 
 		resp, err := client.Do(req)
 

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"sort"
 
 	"golang.org/x/net/lex/httplex"
 
@@ -21,6 +22,12 @@ func Decode(r *bufio.Reader) (Har, error) {
 	if err != nil {
 		log.Error(err)
 	}
+
+	// Sort the entries by StartedDateTime to ensure they will be processed
+	// in the same order as they happened
+	sort.Slice(har.Log.Entries, func(i, j int) bool {
+		return har.Log.Entries[i].StartedDateTime < har.Log.Entries[j].StartedDateTime
+	})
 
 	return har, err
 }


### PR DESCRIPTION
Some Browsers (Chrome in my case) does not put the HAR entries in the same order as they happened. This would result in silly stuff like doing a logout before a login.

Now after Hargo decodes the HAR file, it sorts the entries using the StartedDateTime field value to put them in chronological order.

Also I've applied the some changes to the HttpClient for the Run mode, improving (reducing) the time required to run the scenario once. And it prints out a little bit more info (Method, response HttpCode)