### PR TITLE
New cli flag to ignore the cookies in the HAR entries

### DIFF
--- a/cmd/hargo/hargo.go
+++ b/cmd/hargo/hargo.go
@@ -108,13 +108,19 @@ func main() {
 			UsageText:   "run - execute all requests in .har file",
 			Description: "execute all requests in .har file",
 			ArgsUsage:   "<.har file>",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "ignore-har-cookies",
+					Usage: "Ignore the cookies provided by the HAR entries"},
+			},
 			Action: func(c *cli.Context) {
+				ignoreHarCookies := c.Bool("ignore-har-cookies")
 				harFile := c.Args().First()
 				log.Info("run .har file: ", harFile)
 				file, err := os.Open(harFile)
 				if err == nil {
 					r := newReader(file)
-					hargo.Run(r)
+					hargo.Run(r, ignoreHarCookies)
 				} else {
 					log.Fatal("Cannot open file: ", harFile)
 					os.Exit(-1)
@@ -181,6 +187,9 @@ func main() {
 					Name:  "influxurl, u",
 					Value: "http://localhost:8086/hargo",
 					Usage: "InfluxDB URL (default http://localhost:8086/hargo)"},
+				cli.BoolFlag{
+					Name:  "ignore-har-cookies",
+					Usage: "Ignore the cookies provided by the HAR entries"},
 			},
 			Action: func(c *cli.Context) {
 
@@ -203,13 +212,14 @@ func main() {
 					workers := c.Int("w")
 					duration := c.Int("d")
 					u, err := url.Parse(c.String("u"))
+					ignoreHarCookies := c.Bool("ignore-har-cookies")
 
 					if err != nil {
 						log.Fatal("Invalid InfluxDB URL: ", c.String("u"))
 						os.Exit(-1)
 					}
 
-					hargo.LoadTest(filepath.Base(harFile), r, workers, time.Duration(duration)*time.Second, *u)
+					hargo.LoadTest(filepath.Base(harFile), r, workers, time.Duration(duration)*time.Second, *u, ignoreHarCookies)
 				} else {
 					log.Fatal("Cannot open file: ", harFile)
 					os.Exit(-1)

--- a/run.go
+++ b/run.go
@@ -25,8 +25,6 @@ func Run(r *bufio.Reader) error {
 	}
 
 	for _, entry := range har.Log.Entries {
-		fmt.Printf("[%s] URL: %s\n", entry.Request.Method, entry.Request.URL)
-
 		req, err := EntryToRequest(&entry)
 
 		check(err)
@@ -36,6 +34,8 @@ func Run(r *bufio.Reader) error {
 		resp, err := client.Do(req)
 
 		check(err)
+
+		fmt.Printf("[%s,%v] URL: %s\n", entry.Request.Method, resp.StatusCode, entry.Request.URL)
 
 		if resp != nil {
 			resp.Body.Close()

--- a/run.go
+++ b/run.go
@@ -14,24 +14,24 @@ func Run(r *bufio.Reader) error {
 
 	check(err)
 
+	jar, _ := cookiejar.New(nil)
+
+	client := http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			r.URL.Opaque = r.URL.Path
+			return nil
+		},
+		Jar: jar,
+	}
+
 	for _, entry := range har.Log.Entries {
-		fmt.Printf("URL: %s\n", entry.Request.URL)
+		fmt.Printf("[%s] URL: %s\n", entry.Request.Method, entry.Request.URL)
 
 		req, err := EntryToRequest(&entry)
 
 		check(err)
 
-		jar, _ := cookiejar.New(nil)
-
 		jar.SetCookies(req.URL, req.Cookies())
-
-		client := http.Client{
-			CheckRedirect: func(r *http.Request, via []*http.Request) error {
-				r.URL.Opaque = r.URL.Path
-				return nil
-			},
-			Jar: jar,
-		}
 
 		resp, err := client.Do(req)
 

--- a/run.go
+++ b/run.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Run executes all entries in .har file
-func Run(r *bufio.Reader) error {
+func Run(r *bufio.Reader, ignoreHarCookies bool) error {
 
 	har, err := Decode(r)
 
@@ -25,7 +25,7 @@ func Run(r *bufio.Reader) error {
 	}
 
 	for _, entry := range har.Log.Entries {
-		req, err := EntryToRequest(&entry)
+		req, err := EntryToRequest(&entry, ignoreHarCookies)
 
 		check(err)
 

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"sort"
 
 	"golang.org/x/net/lex/httplex"
 
@@ -21,6 +22,12 @@ func Decode(r *bufio.Reader) (Har, error) {
 	if err != nil {
 		log.Error(err)
 	}
+
+	// Sort the entries by StartedDateTime to ensure they will be processed
+	// in the same order as they happened
+	sort.Slice(har.Log.Entries, func(i, j int) bool {
+		return har.Log.Entries[i].StartedDateTime < har.Log.Entries[j].StartedDateTime
+	})
 
 	return har, err
 }


### PR DESCRIPTION
Some tests creates their own cookies and thus the HAR entries cookies need to be ignored. I added the cli flag "--ignore-har-cookies" to provide this feature. By default, cookies are still included.

I also added a condition on headers to never include the header named "Cookie" in the request. Adding both this header and the cookies to the request would result in duplicated cookies.