### PR TITLE
Fix compile errors

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,24 +1,24 @@
-hash: 0a59be7ebd39b17be5d6c82c7e90e8db6526cceb4fe02b3d040208f3f6eb7503
-updated: 2018-08-03T16:01:42.251955-04:00
+hash: 56dc4b2922466bf4ba4bf2c816be45f509da24827cb413d5665feb25bd86d3ce
+updated: 2018-09-20T16:05:57.622947-07:00
 imports:
 - name: github.com/blang/semver
   version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/influxdata/influxdb
-  version: 7520f0f77e71a7870b41204821ac8cfa95d9704d
+  version: 389de31c961831de0a9f4172173337d4a6193909
   subpackages:
   - client/v2
   - models
   - pkg/escape
 - name: github.com/mrichman/hargo
-  version: 0d27bbf485a68ea17a636f747dd2e6db58321be6
+  version: 79c306bb2a43e1fe61ad38bb07ba86787b8892e6
 - name: github.com/Sirupsen/logrus
   version: 3e01752db0189b9157070a0e1668a620f9a85da2
 - name: golang.org/x/crypto
-  version: 56440b844dfe139a8ac053f4ecac0b20b79058f4
+  version: 0e37d006457bf46f9e6692014ba72ef82c33022c
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -26,7 +26,6 @@ imports:
   subpackages:
   - http/httpguts
   - idna
-  - lex/httplex
 - name: golang.org/x/sys
   version: d8e400bc7db4870d786864138af681469693d18c
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,7 @@ import:
   subpackages:
   - client/v2
 - package: github.com/mrichman/hargo
-  version: ^0.1.0
+  version: ^0.1.1
 - package: golang.org/x/net
   subpackages:
   - http/httpguts


### PR DESCRIPTION
# PR to fix compile errors

When using `go get github.com/mrichman/hargo` and `make build` there are API incompatibilities between the hargo code and the vendored copy of of the library (??)

This PR just updates the glide version pinning of mrichman/hargo to tag v0.1.1  

## error example

```
$ make install                                                                                                                                                    
glide install                                                                                                                                                                     
[WARN]  The name listed in the config file (.) does not match the current location (github.com/mrichman/hargo)                                                                    
[WARN]  Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'                                                                                     
[INFO]  Downloading dependencies. Please wait...                                                                                                                                  
[INFO]  --> Found desired version locally github.com/blang/semver 2ee87856327ba09384cabd113bc6b5d174e9ec0f!                                                                       
[INFO]  --> Found desired version locally github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76!                                                                    
[INFO]  --> Found desired version locally github.com/influxdata/influxdb 7520f0f77e71a7870b41204821ac8cfa95d9704d!                                                                
[INFO]  --> Found desired version locally github.com/mrichman/hargo 0d27bbf485a68ea17a636f747dd2e6db58321be6!                                                                     
[INFO]  --> Found desired version locally github.com/Sirupsen/logrus 3e01752db0189b9157070a0e1668a620f9a85da2!                                                                    
[INFO]  --> Found desired version locally golang.org/x/crypto 56440b844dfe139a8ac053f4ecac0b20b79058f4!                                                                           
[INFO]  --> Found desired version locally golang.org/x/net 92b859f39abd2d91a854c9f9c4621b2f5054a92d!                                                                              
[INFO]  --> Found desired version locally golang.org/x/sys d8e400bc7db4870d786864138af681469693d18c!                                                                              
[INFO]  --> Found desired version locally golang.org/x/text f21a4dfb5e38f5895301dc265a8def02365cc3d0!                                                                             
[INFO]  --> Found desired version locally gopkg.in/urfave/cli.v1 cfb38830724cc34fedffe9a2a29fb54fa9169cd1!                                                                        
[INFO]  Setting references.                                                                                                                                                       
[INFO]  --> Setting version for github.com/Sirupsen/logrus to 3e01752db0189b9157070a0e1668a620f9a85da2.                                                                           
[INFO]  --> Setting version for github.com/davecgh/go-spew to 346938d642f2ec3594ed81d874461961cd0faa76.                                                                           
[INFO]  --> Setting version for github.com/mrichman/hargo to 0d27bbf485a68ea17a636f747dd2e6db58321be6.                                                                            
[INFO]  --> Setting version for github.com/influxdata/influxdb to 7520f0f77e71a7870b41204821ac8cfa95d9704d.                                                                       
[INFO]  --> Setting version for github.com/blang/semver to 2ee87856327ba09384cabd113bc6b5d174e9ec0f.                                                                              
[INFO]  --> Setting version for golang.org/x/sys to d8e400bc7db4870d786864138af681469693d18c.                                                                                     
[INFO]  --> Setting version for golang.org/x/text to f21a4dfb5e38f5895301dc265a8def02365cc3d0.                                                                                    
[INFO]  --> Setting version for golang.org/x/net to 92b859f39abd2d91a854c9f9c4621b2f5054a92d.                                                                                     
[INFO]  --> Setting version for golang.org/x/crypto to 56440b844dfe139a8ac053f4ecac0b20b79058f4.                                                                                  
[INFO]  --> Setting version for gopkg.in/urfave/cli.v1 to cfb38830724cc34fedffe9a2a29fb54fa9169cd1.                                                                               
[INFO]  Exporting resolved dependencies...                                                                                                                                        
[INFO]  --> Exporting github.com/davecgh/go-spew                                                                                                                                  
[INFO]  --> Exporting github.com/blang/semver                                                                                                                                     
[INFO]  --> Exporting github.com/influxdata/influxdb                                                                                                                              
[INFO]  --> Exporting github.com/mrichman/hargo                                                                                                                                   
[INFO]  --> Exporting github.com/Sirupsen/logrus                                                                                                                                  
[INFO]  --> Exporting golang.org/x/text                                                                                                                                           
[INFO]  --> Exporting golang.org/x/sys                                                                                                                                            
[INFO]  --> Exporting gopkg.in/urfave/cli.v1                                                                                                                                      
[INFO]  --> Exporting golang.org/x/crypto                                                                                                                                         
[INFO]  --> Exporting golang.org/x/net                                                                                                                                            
[INFO]  Replacing existing vendor dependencies                                                                                                                                    
go install -ldflags "-s -w -X main.Version=0.1.2-dev.8 -X main.CommitHash=9fcef47 -X 'main.CompileDate=September 20, 2018'" ./cmd/hargo                                           
# github.com/mrichman/hargo/cmd/hargo                                                                                                                                             
cmd/hargo/hargo.go:125:15: too many arguments in call to hargo.Run                                                                                                                
        have (*bufio.Reader, bool)                                                                                                                                                
        want (*bufio.Reader)                                                                                                                                                      
cmd/hargo/hargo.go:224:20: too many arguments in call to hargo.LoadTest                              
        have (string, *bufio.Reader, int, time.Duration, url.URL, bool)                                   
        want (*bufio.Reader, int, time.Duration, url.URL)                                          
make: *** [install] Error 2
```                                                