### PR TITLE
Dockerfile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ clean:
 docker:
 	docker build --rm -t ${IMAGE} --build-arg VERSION="${VERSION}" \
 	--build-arg BUILD_DATE="${BUILD_DATE}" \
+	--build-arg DATE="${DATE}" \
+	--build-arg HASH="${HASH}" \
+	--build-arg VERSION="${VERSION}" \
 	--build-arg VCS_URL="${VCS_URL}" \
 	--build-arg VCS_REF="${VCS_REF}" \
 	--build-arg NAME="${NAME}" \

--- a/README.md
+++ b/README.md
@@ -110,3 +110,17 @@ Dump prints information about all HTTP requests in .har file
 Hargo can act as a load test agent. Given a .har file, hargo can spawn a number of concurrent workers to repeat each HTTP request in order. By default, hargo will spawn 10 workers and run for a duration of 60 seconds.
 
 Hargo will also save its results to [InfluxDB](https://www.influxdata.com/), if available. Each HTTP response is stored as a point of time-series data, which can be graphed by [Chronograf](https://www.influxdata.com/time-series-platform/chronograf/), [Grafana](http://grafana.org/), or similar visualization tool for analysis.
+
+## Docker
+
+### Build container
+
+```docker
+docker build -t hargo .
+```
+
+### Run container
+
+```docker
+docker run --rm -v `pwd`/test:/test hargo hargo run /test/golang.org.har
+```


### PR DESCRIPTION
It seems that your Docker file doesn't work 'out-of-the-box' when build manually or with 'make docker'. It returned permission denied exceptions, so we couldn't run hargo with docker.
The following commands should now work:
```docker
docker build -t hargo .
docker run --rm -v `pwd`/test:/test hargo hargo run /test/golang.org.har
```
Also through the make docker command a workable dockerimage is produced