### PR TITLE
Docker compose & TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Hargo will also save its results to [InfluxDB](https://www.influxdata.com/), if 
 
 ## Docker
 
-### Build container
+### [Build container](#build)
 
 ```docker
 docker build -t hargo .
@@ -123,4 +123,21 @@ docker build -t hargo .
 
 ```docker
 docker run --rm -v `pwd`/test:/test hargo hargo run /test/golang.org.har
+```
+
+## Docker-compose
+
+The example docker-compose file will start three containers:
+
+- hargo
+- influxdb
+- grafana
+
+The hargo container will first needs to be [build](#build). When the compose file is run it will start a hargo load process that will writes the results into the influxdb. This influxdb can be view with the grafana container that contains a example dashboard show the latency.
+
+### start
+
+```docker-compose
+docker-compose up
+docker-compose down -v
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Hargo will also save its results to [InfluxDB](https://www.influxdata.com/), if 
 
 ## Docker
 
-### [Build container](#build)
+### Build container
 
 ```docker
 docker build -t hargo .
@@ -133,9 +133,9 @@ The example docker-compose file will start three containers:
 - influxdb
 - grafana
 
-The hargo container will first needs to be [build](#build). When the compose file is run it will start a hargo load process that will writes the results into the influxdb. This influxdb can be view with the grafana container that contains a example dashboard show the latency.
+The hargo container will first needs to be [build](#build-container). When the compose file is run it will start a hargo load process that will writes the results into the influxdb. This influxdb can be view with the grafana container that contains a example dashboard show the latency.
 
-### start
+### commands
 
 ```docker-compose
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The example docker-compose file will start three containers:
 - influxdb
 - grafana
 
-The hargo container will first needs to be [build](#build-container). When the compose file is run it will start a hargo load process that will writes the results into the influxdb. This influxdb can be view with the grafana container that contains a example dashboard show the latency.
+The hargo container will first needs to be [build](#build-container). When the compose file is run it will start a hargo load process that will writes the results into the influxdb. This influxdb can be viewed with the [grafana container](http://localhost:3000) that contains a example dashboard showing the latency of the executed request. Username and password for all the containers is hargo/hargo.
 
 ### commands
 

--- a/cmd/hargo/hargo.go
+++ b/cmd/hargo/hargo.go
@@ -114,15 +114,19 @@ func main() {
 				cli.BoolFlag{
 					Name:  "ignore-har-cookies",
 					Usage: "Ignore the cookies provided by the HAR entries"},
+				cli.BoolFlag{
+					Name:  "insecure-skip-verify",
+					Usage: "Skips the TLS security checks"},
 			},
 			Action: func(c *cli.Context) {
 				ignoreHarCookies := c.Bool("ignore-har-cookies")
+				insecureSkipVerify := c.Bool("insecure-skip-verify")
 				harFile := c.Args().First()
 				log.Info("run .har file: ", harFile)
 				file, err := os.Open(harFile)
 				if err == nil {
 					r := newReader(file)
-					hargo.Run(r, ignoreHarCookies)
+					hargo.Run(r, ignoreHarCookies, insecureSkipVerify)
 				} else {
 					log.Fatal("Cannot open file: ", harFile)
 					os.Exit(-1)
@@ -192,6 +196,9 @@ func main() {
 				cli.BoolFlag{
 					Name:  "ignore-har-cookies",
 					Usage: "Ignore the cookies provided by the HAR entries"},
+				cli.BoolFlag{
+					Name:  "insecure-skip-verify",
+					Usage: "Skips the TLS security checks"},
 			},
 			Action: func(c *cli.Context) {
 
@@ -215,13 +222,14 @@ func main() {
 					duration := c.Int("d")
 					u, err := url.Parse(c.String("u"))
 					ignoreHarCookies := c.Bool("ignore-har-cookies")
+					insecureSkipVerify := c.Bool("insecure-skip-verify")
 
 					if err != nil {
 						log.Fatal("Invalid InfluxDB URL: ", c.String("u"))
 						os.Exit(-1)
 					}
 
-					hargo.LoadTest(filepath.Base(harFile), r, workers, time.Duration(duration)*time.Second, *u, ignoreHarCookies)
+					hargo.LoadTest(filepath.Base(harFile), r, workers, time.Duration(duration)*time.Second, *u, ignoreHarCookies, insecureSkipVerify)
 				} else {
 					log.Fatal("Cannot open file: ", harFile)
 					os.Exit(-1)

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  influxdb:
+    image: influxdb:latest
+    ports:
+      - '8086:8086'
+    volumes:
+      - influxdb:/var/lib/influxdb
+    environment:
+      - INFLUXDB_DB=hargo
+      - INFLUXDB_ADMIN_USER=hargo
+      - INFLUXDB_ADMIN_PASSWORD=hargo
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - '3000:3000'
+    volumes:
+      - grafana:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning
+    depends_on:
+      - influxdb
+    environment:
+      - GF_SECURITY_ADMIN_USER=hargo
+      - GF_SECURITY_ADMIN_PASSWORD=hargo
+volumes:
+  grafana: 
+  influxdb:

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -1,5 +1,12 @@
 version: '3'
 services:
+  hargo:
+    image: hargo
+    command: hargo load -u=http://influxdb:8086/hargo -insecure-skip-verify=true /test/golang.org.har
+    volumes:
+      - ../../test:/test
+    depends_on:
+      - influxdb  
   influxdb:
     image: influxdb:latest
     ports:

--- a/example/docker-compose/grafana/provisioning/dashboards/Latency.json
+++ b/example/docker-compose/grafana/provisioning/dashboards/Latency.json
@@ -1,0 +1,167 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Hargo",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_result",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Latency"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 19,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Latency",
+  "uid": "IpxadyOWz",
+  "version": 1
+}

--- a/example/docker-compose/grafana/provisioning/dashboards/dashboard.yml
+++ b/example/docker-compose/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+- name: Hargo
+  folder: 'hargo'
+  type: file
+  disableDeletion: false
+  editable: true
+  options:
+    path: /etc/grafana/provisioning/dashboards

--- a/example/docker-compose/grafana/provisioning/datasources/datasource.yml
+++ b/example/docker-compose/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Hargo
+    type: influxdb
+    access: proxy
+    database: hargo
+    user: hargo
+    password: hargo
+    url: http://influxdb:8086
+    isDefault: true
+    editable: true

--- a/influxdb.go
+++ b/influxdb.go
@@ -27,6 +27,19 @@ func NewInfluxDBClient(u url.URL) (client.Client, error) {
 		return c, err
 	}
 
+	retry := 1
+
+	for retry < 3 {
+		_, resp, e := c.Ping(2 * time.Second)
+		if e != nil {
+			retry++
+			time.Sleep(10 * time.Second)
+		} else if len(resp) > 0 {
+			log.Println("Version InfluxDB: " + resp)
+			break
+		}
+	}
+
 	db = strings.Replace(u.Path, "/", "", -1)
 
 	log.Info("DB: ", db)

--- a/run.go
+++ b/run.go
@@ -2,13 +2,14 @@ package hargo
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
 )
 
 // Run executes all entries in .har file
-func Run(r *bufio.Reader, ignoreHarCookies bool) error {
+func Run(r *bufio.Reader, ignoreHarCookies bool, insecureSkipVerify bool) error {
 
 	har, err := Decode(r)
 
@@ -22,6 +23,9 @@ func Run(r *bufio.Reader, ignoreHarCookies bool) error {
 			return nil
 		},
 		Jar: jar,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+		},
 	}
 
 	for _, entry := range har.Log.Entries {


### PR DESCRIPTION
Seeing that hargo works with influxdb I included a docker-compose example with hargo, influxdb and grafana. To get it working I needed to include a retry mechanisme to check if the influxdb is running, seeing that in docker-compose (3.x) the [depends_on](https://docs.docker.com/compose/compose-file/#depends_on) option doesn't support the check 'condition' of the depending containers. 
Regarding the TLSClientConfig I added the commandline option to disable this (default it's enabled), seeing that the baseimage is based on scratch, one would always need to include the certificates by building specific new images by layering on the standard base. This would make to time-to-succeed quite high.