### PR TITLE
build context in compose file

### DIFF
--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   hargo:
+    build:
+      context: ../../  
     image: hargo
     command: hargo load -u=http://influxdb:8086/hargo -insecure-skip-verify=true /test/golang.org.har
     volumes:


### PR DESCRIPTION
Hi @mrichman 
I have added a build step in de docker-compose, so the hargo image is build when it's not already available.

Regarding the ERROR's you face, I have not been able to reproduce it.
Tested on:
- MacOS 10.14.6
- Docker 19.03.1
- Docker-compose 1.24.1

I was wondering what are your file sharing permissions?
Does it include the /Users 
![image](https://user-images.githubusercontent.com/15999389/63412291-be62df80-c3f7-11e9-8dc7-9ce4d139cf84.png)

