### PR TITLE
added cert from build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN go mod download
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 
+RUN apk add -U --no-cache ca-certificates
+
 RUN go build -ldflags "-s -w -X main.Version=$VERSION -X main.CommitHash=$HASH -X 'main.CompileDate=$DATE'" -o hargo ./cmd/hargo
 
 # final stage
@@ -24,6 +26,7 @@ FROM scratch
 WORKDIR /
 ENV PATH=/
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/hargo/hargo /
 
 # Metadata params

--- a/example/docker-compose/docker-compose.yml
+++ b/example/docker-compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../  
     image: hargo
-    command: hargo load -u=http://influxdb:8086/hargo -insecure-skip-verify=true /test/golang.org.har
+    command: hargo load -u=http://influxdb:8086/hargo /test/golang.org.har
     volumes:
       - ../../test:/test
     depends_on:


### PR DESCRIPTION
The behaviour now, regarding certificates is.

|url|host| docker |host + ignore tls| docker + ignore tls|
|---|---|---|---|---|
|http| pass | pass |pass |pass |
|https + ca cert| pass | error | pass | pass |
|https + self-signed cert| error | error |pass | pass |

Issue with the dockerimage is that is ```FROM scratch```, moving to alpine or copying the ca-certificates from the build stage would solve the certificate issue, with the exception of the self-signed ones. Those would be needed to be also included in the truststore.

The first option would be changing the ```FROM scratch``` with something like ```FROM alpine:3.10``` this would increase the size of the image. Or adding in the build stage the command ```RUN apk add -U --no-cache ca-certificates``` and in the final stage ```COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/```

The last option would be the one I would chose, and then the option ```-insecure-skip-verify``` would only really be needed for self-signed certificates.
