### PR TITLE
Load test restructure

### DIFF
--- a/cmd/hargo/hargo.go
+++ b/cmd/hargo/hargo.go
@@ -191,8 +191,7 @@ func main() {
 					Usage: "Test duration in seconds (default 60)"},
 				cli.StringFlag{
 					Name:  "influxurl, u",
-					Value: "http://localhost:8086/hargo",
-					Usage: "InfluxDB URL (default http://localhost:8086/hargo)"},
+					Usage: "InfluxDB URL"},
 				cli.BoolFlag{
 					Name:  "ignore-har-cookies",
 					Usage: "Ignore the cookies provided by the HAR entries"},

--- a/example/docker-compose/grafana/provisioning/dashboards/hargo.json
+++ b/example/docker-compose/grafana/provisioning/dashboards/hargo.json
@@ -18,6 +18,122 @@
   "links": [],
   "panels": [
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Hargo",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "pluginVersion": "6.3.3",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "test_result",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "Method"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "count"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Count",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "total"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -29,7 +145,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 2,
       "legend": {
@@ -97,7 +213,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Panel Title",
+      "title": "Latency",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -161,7 +277,7 @@
     ]
   },
   "timezone": "",
-  "title": "Latency",
-  "uid": "IpxadyOWz",
+  "title": "results",
+  "uid": "aQg9r4KZk",
   "version": 1
 }

--- a/influxdb.go
+++ b/influxdb.go
@@ -62,7 +62,6 @@ func WritePoint(u url.URL, results chan TestResult) {
 	c, err := NewInfluxDBClient(u)
 
 	if err != nil {
-		useInfluxDB = false
 		log.Warn("No test results will be recorded to InfluxDB")
 	} else {
 		log.Info("Recording results to InfluxDB: ", u.String())

--- a/influxdb.go
+++ b/influxdb.go
@@ -12,8 +12,8 @@ import (
 
 var db string
 
-// NewInfluxDBClient returns a new InfluxDB client
-func NewInfluxDBClient(u url.URL) (client.Client, error) {
+// newInfluxDBClient returns a new InfluxDB client
+func newInfluxDBClient(u url.URL) (client.Client, error) {
 
 	addr := fmt.Sprintf("%s://%s:%s", u.Scheme, u.Hostname(), u.Port())
 	log.Print("Connecting to InfluxDB: ", addr)
@@ -56,10 +56,9 @@ func NewInfluxDBClient(u url.URL) (client.Client, error) {
 	return c, nil
 }
 
-// WritePoint is WritePoint
+// WritePoint inserts data to InfluxDB
 func WritePoint(u url.URL, results chan TestResult) {
-
-	c, err := NewInfluxDBClient(u)
+	c, err := newInfluxDBClient(u)
 
 	if err != nil {
 		log.Warn("No test results will be recorded to InfluxDB")

--- a/load.go
+++ b/load.go
@@ -23,8 +23,10 @@ func LoadTest(harfile string, file *os.File, workers int, timeout time.Duration,
 	stop := make(chan bool)
 	entries := make(chan Entry)
 
-	go readHARStream(file, entries, stop)
+	go ReadStream(file, entries, stop)
 
+	// if a InfluxDB URL is given the metrics will be written to that instance
+	// if not the dummy consumer is initiated.
 	if (url.URL{}) != u {
 		go WritePoint(u, results)
 	} else {
@@ -44,7 +46,6 @@ func LoadTest(harfile string, file *os.File, workers int, timeout time.Duration,
 	for {
 		select {
 		case <-stop:
-			log.Infoln("stop main")
 		}
 		break
 	}
@@ -52,9 +53,9 @@ func LoadTest(harfile string, file *os.File, workers int, timeout time.Duration,
 	return nil
 }
 
+// wait will close the stop chan when the timeout is hit.
 func wait(stop chan bool, timeout time.Duration, workers int) {
 	time.Sleep(timeout)
-	log.Infoln("TIMEOUT")
 	close(stop)
 }
 

--- a/load.go
+++ b/load.go
@@ -1,23 +1,21 @@
 package hargo
 
 import (
-	"bufio"
 	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
-var useInfluxDB = true // just in case we can't connect, run tests without recording results
-
 // LoadTest executes all HTTP requests in order concurrently
 // for a given number of workers.
-func LoadTest(harfile string, r *bufio.Reader, workers int, timeout time.Duration, u url.URL, ignoreHarCookies bool, insecureSkipVerify bool) error {
+func LoadTest(harfile string, file *os.File, workers int, timeout time.Duration, u url.URL, ignoreHarCookies bool, insecureSkipVerify bool) error {
 	log.Infof("Starting load test with %d workers. Duration %v.", workers, timeout)
 
 	results := make(chan TestResult)
@@ -25,7 +23,7 @@ func LoadTest(harfile string, r *bufio.Reader, workers int, timeout time.Duratio
 	stop := make(chan bool)
 	entries := make(chan Entry)
 
-	go readHARStream(r, entries, stop)
+	go readHARStream(file, entries, stop)
 
 	if (url.URL{}) != u {
 		go WritePoint(u, results)

--- a/load.go
+++ b/load.go
@@ -27,7 +27,15 @@ func LoadTest(harfile string, r *bufio.Reader, workers int, timeout time.Duratio
 
 	go readHARStream(r, entries, stop)
 
-	go WritePoint(u, results)
+	if (url.URL{}) != u {
+		go WritePoint(u, results)
+	} else {
+		go func(results chan TestResult) {
+			for {
+				<-results
+			}
+		}(results)
+	}
 
 	go wait(stop, timeout, workers)
 

--- a/load.go
+++ b/load.go
@@ -2,9 +2,12 @@ package hargo
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
 	"net/url"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -16,166 +19,115 @@ var useInfluxDB = true // just in case we can't connect, run tests without recor
 // for a given number of workers.
 func LoadTest(harfile string, r *bufio.Reader, workers int, timeout time.Duration, u url.URL, ignoreHarCookies bool, insecureSkipVerify bool) error {
 	log.Infof("Starting load test with %d workers. Duration %v.", workers, timeout)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	wg.Add(1)
-	wg.Add(1)
 
-	// tr := make(chan TestResult)
-	// defer close(tr)
-
-	e := make(chan Entry)
-	defer close(e)
-
+	results := make(chan TestResult)
+	defer close(results)
 	stop := make(chan bool)
-	defer close(stop)
+	entries := make(chan Entry)
 
-	go readHARStream(r, e, &wg, stop)
+	go readHARStream(r, entries, stop)
 
-	go wait(stop, timeout, workers, &wg)
+	go WritePoint(u, results)
+
+	go wait(stop, timeout, workers)
 
 	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go processEntries(harfile, e, &wg, ignoreHarCookies, insecureSkipVerify, stop)
+		go processEntries(harfile, entries, results, ignoreHarCookies, insecureSkipVerify, stop)
 	}
 
-	// go func(harfile string, e chan Entry, wg *sync.WaitGroup, ignoreHarCookies bool, insecureSkipVerify bool, results chan TestResult, workers int, done chan int, stop chan bool) {
-
-	// 	done <- 0
-	// 	defer wg.Done()
-	// 	j := 0
-	// loop:
-	// 	for {
-	// 		select {
-	// 		case <-stop:
-
-	// 			break loop
-	// 		case entry := <-e:
-	// 			for {
-	// 				i := <-done
-	// 				j = j + i
-	// 				if j < workers {
-	// 					done <- 1
-	// 					wg.Add(1)
-	// 					go processEntries(harfile, entry, wg, ignoreHarCookies, insecureSkipVerify, tr, done)
-	// 					break
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// 	log.Infoln("stop processing")
-	// }(harfile, e, &wg, ignoreHarCookies, insecureSkipVerify, tr, workers, done, stop)
-
-loop:
 	for {
 		select {
 		case <-stop:
 			log.Infoln("stop main")
-			break loop
 		}
+		break
 	}
-
-	defer wg.Wait()
 	fmt.Printf("\nTimeout of %.1fs elapsed. Terminating load test.\n", timeout.Seconds())
 	return nil
 }
 
-func wait(stop chan bool, timeout time.Duration, workers int, wg *sync.WaitGroup) {
-	defer wg.Done()
+func wait(stop chan bool, timeout time.Duration, workers int) {
 	time.Sleep(timeout)
 	log.Infoln("TIMEOUT")
-	// once for the timer and once for the entry queue
-	stop <- true
-	stop <- true
-	stop <- true
-	for i := 0; i < workers; i++ {
-		stop <- true
-	}
+	close(stop)
 }
 
-func processEntries(harfile string, e chan Entry, wg *sync.WaitGroup, ignoreHarCookies bool, insecureSkipVerify bool, stop chan bool) {
-	defer wg.Done()
-process:
+func processEntries(harfile string, entries chan Entry, results chan TestResult, ignoreHarCookies bool, insecureSkipVerify bool, stop chan bool) {
+	jar, _ := cookiejar.New(nil)
+
+	httpClient := http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecureSkipVerify},
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			r.URL.Opaque = r.URL.Path
+			return nil
+		},
+		Jar: jar,
+	}
+	iter := 0
 	for {
+
 		select {
 		case <-stop:
-			break process
-		case entry := <-e:
-			time.Sleep(1 * time.Second)
-			log.Infoln(entry.Request.URL)
+			break
+		case entry := <-entries:
+			msg := fmt.Sprintf("[%d,%d] %s", 1, iter, entry.Request.URL)
+
+			req, err := EntryToRequest(&entry, ignoreHarCookies)
+
+			check(err)
+
+			jar.SetCookies(req.URL, req.Cookies())
+
+			startTime := time.Now()
+			resp, err := httpClient.Do(req)
+			endTime := time.Now()
+			latency := int(endTime.Sub(startTime) / time.Millisecond)
+			method := req.Method
+
+			if err != nil {
+
+				log.Error(err)
+				log.Error(entry)
+				tr := TestResult{
+					URL:       req.URL.String(),
+					Status:    0,
+					StartTime: startTime,
+					EndTime:   endTime,
+					Latency:   latency,
+					Method:    method,
+					HarFile:   harfile}
+				results <- tr
+				continue
+			}
+
+			if resp != nil {
+				resp.Body.Close()
+			}
+
+			msg += fmt.Sprintf(" %d %dms", resp.StatusCode, latency)
+
+			log.Infoln(msg)
+
+			tr := TestResult{
+				URL:       req.URL.String(),
+				Status:    resp.StatusCode,
+				StartTime: startTime,
+				EndTime:   endTime,
+				Latency:   latency,
+				Method:    method,
+				HarFile:   harfile}
+
+			results <- tr
 		}
+		iter++
 	}
-
-	// log.Infoln(entry)
-	// jar, _ := cookiejar.New(nil)
-
-	// httpClient := http.Client{
-	// 	Transport: &http.Transport{
-	// 		Dial: (&net.Dialer{
-	// 			Timeout:   1 * time.Second,
-	// 			KeepAlive: 1 * time.Second,
-	// 		}).Dial,
-	// 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-	// 		TLSHandshakeTimeout:   1 * time.Second,
-	// 		ResponseHeaderTimeout: 1 * time.Second,
-	// 		ExpectContinueTimeout: 1 * time.Second,
-	// 	},
-	// 	CheckRedirect: func(r *http.Request, via []*http.Request) error {
-	// 		r.URL.Opaque = r.URL.Path
-	// 		return nil
-	// 	},
-	// 	Jar: jar,
-	// }
-
-	// iter := 0
-
-	// msg := fmt.Sprintf("[%d,%d] %s", 1, iter, entry.Request.URL)
-
-	// req, err := EntryToRequest(&entry, ignoreHarCookies)
-
-	// check(err)
-
-	// jar.SetCookies(req.URL, req.Cookies())
-
-	// startTime := time.Now()
-	// resp, err := httpClient.Do(req)
-	// endTime := time.Now()
-	// latency := int(endTime.Sub(startTime) / time.Millisecond)
-	// method := req.Method
-
-	// if err != nil {
-
-	// 	log.Error(err)
-	// 	log.Error(entry)
-	// 	tr := TestResult{
-	// 		URL:       req.URL.String(),
-	// 		Status:    0,
-	// 		StartTime: startTime,
-	// 		EndTime:   endTime,
-	// 		Latency:   latency,
-	// 		Method:    method,
-	// 		HarFile:   harfile}
-
-	// 	results <- tr
-	// 	return
-	// }
-
-	// if resp != nil {
-	// 	resp.Body.Close()
-	// }
-
-	// msg += fmt.Sprintf(" %d %dms", resp.StatusCode, latency)
-
-	// log.Debug(msg)
-
-	// tr := TestResult{
-	// 	URL:       req.URL.String(),
-	// 	Status:    resp.StatusCode,
-	// 	StartTime: startTime,
-	// 	EndTime:   endTime,
-	// 	Latency:   latency,
-	// 	Method:    method,
-	// 	HarFile:   harfile}
-	// results <- tr
-
 }

--- a/read.go
+++ b/read.go
@@ -12,7 +12,8 @@ import (
 
 func readHARStream(r *bufio.Reader, entries chan Entry, wg *sync.WaitGroup) {
 	defer wg.Done()
-	log.Infoln("readHARStream")
+
+	log.Infoln("reading HAR file")
 	decoder := json.NewDecoder(r)
 loop:
 	for {
@@ -41,7 +42,6 @@ loop:
 			log.Fatal(err)
 		}
 		if len(e.Request.URL) > 0 {
-			// log.Infoln(e.Request.URL)
 			entries <- e
 		}
 	}

--- a/read.go
+++ b/read.go
@@ -1,60 +1,65 @@
 package hargo
 
 import (
-	"bufio"
 	"encoding/json"
+	"io"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 )
 
 //https://golang.org/pkg/encoding/json/#example_Decoder_Decode_stream
 
-func readHARStream(r *bufio.Reader, entries chan Entry, stop chan bool) {
+func readHARStream(file *os.File, entries chan Entry, stop chan bool) {
 
-	log.Infoln("reading HAR file")
-	decoder := json.NewDecoder(r)
-
-	// navigate to entries
-loop:
 	for {
-		t, _ := decoder.Token()
-		if t == nil {
-			break
-		}
-		switch token := t.(type) {
-		case json.Token:
-			if token == "entries" {
-				break loop
+		r := NewReader(file)
+
+		log.Infoln("reading HAR file")
+		decoder := json.NewDecoder(r)
+
+		// navigate to entries
+	loop:
+		for {
+			t, _ := decoder.Token()
+			if t == nil {
+				break
+			}
+			switch token := t.(type) {
+			case json.Token:
+				if token == "entries" {
+					break loop
+				}
 			}
 		}
-	}
 
-	// skip open bracket
-	_, err := decoder.Token()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// read entries
-	for decoder.More() {
-		var e Entry
-		err := decoder.Decode(&e)
+		// skip open bracket
+		_, err := decoder.Token()
 		if err != nil {
 			log.Fatal(err)
 		}
-		if len(e.Request.URL) > 0 {
-			entries <- e
-		}
 
-		select {
-		default:
-			continue
-		case <-stop:
-			log.Infoln("stop reading HAR file")
-			close(entries)
-			return
+		// read entries
+		for decoder.More() {
+			var e Entry
+			err := decoder.Decode(&e)
+			if err != nil {
+				log.Fatal(err)
+			}
+			if len(e.Request.URL) > 0 {
+				entries <- e
+			}
+
+			select {
+			default:
+				continue
+			case <-stop:
+				log.Infoln("stop reading HAR file")
+				close(entries)
+				return
+			}
 		}
+		log.Infoln("read HAR file")
+		file.Seek(0, io.SeekStart)
 	}
-	log.Infoln("read HAR file")
-	return
 }

--- a/read.go
+++ b/read.go
@@ -1,0 +1,50 @@
+package hargo
+
+import (
+	"bufio"
+	"encoding/json"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+//https://golang.org/pkg/encoding/json/#example_Decoder_Decode_stream
+
+func readHARStream(r *bufio.Reader, entries chan Entry, wg *sync.WaitGroup) {
+	defer wg.Done()
+	log.Infoln("readHARStream")
+	decoder := json.NewDecoder(r)
+loop:
+	for {
+		t, _ := decoder.Token()
+		if t == nil {
+			break
+		}
+		switch token := t.(type) {
+		case json.Token:
+			if token == "entries" {
+				break loop
+			}
+		}
+	}
+
+	// skip open bracket
+	_, err := decoder.Token()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for decoder.More() {
+		var e Entry
+		err := decoder.Decode(&e)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(e.Request.URL) > 0 {
+			// log.Infoln(e.Request.URL)
+			entries <- e
+		}
+	}
+
+	log.Infoln("read HAR file")
+}

--- a/read.go
+++ b/read.go
@@ -8,10 +8,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//https://golang.org/pkg/encoding/json/#example_Decoder_Decode_stream
-
-func readHARStream(file *os.File, entries chan Entry, stop chan bool) {
-
+// ReadStream reads the har file as a stream and puts the entries
+// on a chan for consumption. When the end of a file is reached it
+// will start over until the stop signal is given.
+// https://golang.org/pkg/encoding/json/#example_Decoder_Decode_stream
+func ReadStream(file *os.File, entries chan Entry, stop chan bool) {
 	for {
 		r := NewReader(file)
 

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"sort"
@@ -77,4 +78,22 @@ func check(err error) {
 	if err != nil {
 		log.Error(err)
 	}
+}
+
+// NewReader returns a bufio.Reader that will skip over initial UTF-8 byte order marks.
+// https://tools.ietf.org/html/rfc7159#section-8.1
+func NewReader(r io.Reader) *bufio.Reader {
+
+	buf := bufio.NewReader(r)
+	b, err := buf.Peek(3)
+	if err != nil {
+		// not enough bytes
+		return buf
+	}
+	if b[0] == 0xef && b[1] == 0xbb && b[2] == 0xbf {
+		log.Warn("BOM detected. Skipping first 3 bytes of file. Consider removing the BOM from this file. " +
+			"See https://tools.ietf.org/html/rfc7159#section-8.1 for details.")
+		buf.Discard(3)
+	}
+	return buf
 }


### PR DESCRIPTION
Regarding a issue we were facing I've restructured the 'load' test, main changes are:
* synchronization: waitgroups -> chan
* streaming the har file, instead for reading it in memory (sorting of the requests is skipped)
* requests in a har file are divided between the workers, instead of each worker processes the same file
* every result/point is pushed individually to influxdb
* moved the NewReader to the utils.go

grafana:
* added request count example dashboard