### PR TITLE
Added support for Playwright's _file option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 )
 
 require (
-	github.com/blang/semver v2.2.0+incompatible // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/blang/semver v2.2.0+incompatible h1:DIb+hEi/XKX6t9Cvy5+oSlANqmc0eenMxbNBvLqpV2A=
-github.com/blang/semver v2.2.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c h1:qSHzRbhzK8RdXOsAdfDgO49TtqC1oZ+acxPrkfTxcCs=

--- a/types.go
+++ b/types.go
@@ -272,6 +272,9 @@ type Content struct {
 	Encoding string `json:"encoding,omitempty"`
 	// optional (new in 1.2) A comment provided by the user or the application.
 	Comment string `json:"comment,omitempty"`
+	// optional (community enhancement) A path to an attached file containing this content
+	// used by Playwright
+	File string `json:"_file,omitempty"`
 }
 
 // Cache contains info about a request coming from browser cache.


### PR DESCRIPTION
Playwright has a `attach` option for response content within a  HAR: https://playwright.dev/docs/api/class-browser

I've added support for the `_file` property that Playwright uses to store the attachment location. Fairly rudimentary: let me know if you'd rather this be more expansive (as there's a few more custom properties that Playwright includes) or if you've got an alternate way to handle non-standard HAR properties :) 