### PR TITLE
CURL: Introduce Shell Escaping Support

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/alessio/shellescape"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -50,18 +51,18 @@ func fromEntry(entry Entry) (string, error) {
 		for _, cookie := range entry.Request.Cookies {
 			cookies = append(cookies, url.QueryEscape(cookie.Name)+"="+url.QueryEscape(cookie.Value))
 		}
-		command += " -b \"" + strings.Join(cookies[:], "&") + "\" "
+		command += " -b " + shellescape.Quote(strings.Join(cookies[:], "&")) + " "
 	}
 
 	for _, h := range entry.Request.Headers {
-		command += " -H \"" + h.Name + ": " + h.Value + "\" "
+		command += " -H " + shellescape.Quote(h.Name+": "+h.Value) + " "
 	}
 
 	if entry.Request.Method == "POST" && len(entry.Request.PostData.Text) > 0 {
-		command += "-d \"" + entry.Request.PostData.Text + "\""
+		command += "-d " + shellescape.Quote(entry.Request.PostData.Text)
 	}
 
-	command += " \"" + entry.Request.URL + "\""
+	command += " " + shellescape.Quote(entry.Request.URL)
 
 	return command, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/alessio/shellescape v1.4.2 // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
+github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c h1:qSHzRbhzK8RdXOsAdfDgO49TtqC1oZ+acxPrkfTxcCs=


### PR DESCRIPTION
In scenarios where a header, POST data, or cookie includes a double quote, such as in the case of Sec-Ch-Ua-Arch with the value '"x86"', the generated curl command line may fail due to inadequate escaping.

This patch introduces shell escaping support for curl commands, guaranteeing that the curl output consistently functions as expected.