### PR TITLE
Add extract command to extract HAR response content to filesystem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.22, 1.23]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+    
+    - name: Install dependencies
+      run: go mod download
+    
+    - name: Run tests
+      run: make test
+    
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.out
+        fail_ci_if_error: false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,104 @@
 {
   "version": "0.2.0",
-  "configurations": [{
-    "name": "Debug test file",
-    "type": "go",
-    "request": "launch",
-    "mode": "debug",
-    "program": "${workspaceFolder}/cmd/hargo/hargo.go",
-    "env": {},
-    "args": ["--", "f", "${workspaceFolder}/test/en.wikipedia.org.har"]
-  }]
+  "configurations": [
+    {
+      "name": "hargo: fetch",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["fetch", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: curl",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["curl", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: run",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["run", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: run (ignore cookies)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["run", "--ignore-har-cookies", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: validate",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["validate", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: dump",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["dump", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: extract (by domain)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["extract", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: extract (by type)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["extract", "--sort", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: load test",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["load", "--workers", "2", "--duration", "10", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: load test (with InfluxDB)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["load", "--workers", "2", "--duration", "10", "--influxurl", "http://localhost:8086", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "name": "hargo: debug mode",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hargo",
+      "args": ["--debug", "dump", "test/golang.org.har"],
+      "cwd": "${workspaceFolder}"
+    }
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ update:
 
 test:
 	$(GO) install
-	$(GO) test ./cmd/hargo/main
+	$(GO) test ./...
+	$(GO) test -race -coverprofile=coverage.out -covermode=atomic ./...
 
 clean:
 	rm -f hargo

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ COMMANDS:
      run, r       Run .har file
      validate, v  Validate .har file
      dump, d      Dump .har file
+     extract, e   Extract content from .har file
      load, l      Load test .har file
      help, h      Shows a list of commands or help for one command
 
@@ -95,6 +96,16 @@ HAR file format is defined here: <https://w3c.github.io/web-performance/specs/HA
 Dump prints information about all HTTP requests in .har file
 
 `hargo dump foo.har`
+
+### Extract
+
+Extract response content from .har file to filesystem
+
+`hargo extract foo.har`
+
+This will create a timestamped directory containing all response content organized by domain. Use `--sort` to organize by content type instead.
+
+`hargo extract --sort foo.har`
 
 ### Load
 

--- a/cmd/hargo/hargo.go
+++ b/cmd/hargo/hargo.go
@@ -232,6 +232,36 @@ func main() {
 				}
 			},
 		},
+		{
+			Name:        "extract",
+			Aliases:     []string{"e"},
+			Usage:       "Extract content from .har file",
+			UsageText:   "extract - extract response content from .har file to filesystem",
+			Description: "extract all response content from .har file, organizing by domain or content type",
+			ArgsUsage:   "<.har file>",
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "sort, s",
+					Usage: "Sort files by content type instead of domain"},
+			},
+			Action: func(c *cli.Context) {
+				harFile := c.Args().First()
+				sortByType := c.Bool("sort")
+				log.Infof("extract .har file: %s", harFile)
+				file, err := os.Open(harFile)
+				if err == nil {
+					r := hargo.NewReader(file)
+					err = hargo.Extract(r, sortByType)
+					if err != nil {
+						log.Fatal("Extract failed: ", err)
+						os.Exit(-1)
+					}
+				} else {
+					log.Fatal("Cannot open file: ", harFile)
+					os.Exit(-1)
+				}
+			},
+		},
 	}
 
 	app.Run(os.Args)

--- a/extract.go
+++ b/extract.go
@@ -1,0 +1,374 @@
+package hargo
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/csv"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ManifestEntry represents metadata for a single extracted file,
+// tracking its original location and extraction details for audit purposes.
+type ManifestEntry struct {
+	OriginalURL   string `json:"originalUrl"`
+	ExtractedPath string `json:"extractedPath"`
+	MimeType      string `json:"mimeType"`
+	Size          int    `json:"size"`
+	Method        string `json:"method"`
+	Status        int    `json:"status"`
+}
+
+// Extract extracts response content from .har file to filesystem.
+// Creates timestamped output directory and organizes files by domain or MIME type.
+// sortByType=true groups files by content type (images/, json/, etc.),
+// sortByType=false preserves original domain structure from URLs.
+// Returns error if HAR parsing fails or file system operations fail.
+func Extract(r *bufio.Reader, sortByType bool) error {
+	har, err := Decode(r)
+	if err != nil {
+		return err
+	}
+
+	// Create timestamped output directory to avoid conflicts with previous extractions
+	datestring := time.Now().Format("20060102150405")
+	outdir := "." + string(filepath.Separator) + "hargo-extract-" + datestring
+
+	err = os.Mkdir(outdir, 0777)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Extracting HAR content to: %s\n", outdir)
+	if sortByType {
+		fmt.Println("Organizing files by content type...")
+	} else {
+		fmt.Println("Organizing files by domain...")
+	}
+
+	// Track filenames to avoid collisions when multiple entries have same name.
+	// filenameCount maps filename -> occurrence count for collision handling.
+	// manifest accumulates metadata for all successfully extracted files.
+	filenameCount := make(map[string]int)
+	var manifest []ManifestEntry
+
+	// Process each HAR entry, extracting response content if present
+	for i, entry := range har.Log.Entries {
+		if entry.Response.Content.Text == "" {
+			log.Debugf("Skipping entry %d: no response content", i)
+			continue
+		}
+
+		parsedURL, err := url.Parse(entry.Request.URL)
+		if err != nil {
+			log.Errorf("Failed to parse URL %s: %v", entry.Request.URL, err)
+			continue
+		}
+
+		var fullPath string
+		var filename string
+
+		if sortByType {
+			// Organize files into type-based directories (images/, json/, css/, etc.)
+			// This mode groups similar content together for easier browsing
+			typeDir := getTypeDirectory(entry.Response.Content.MimeType)
+			fullTypeDir := filepath.Join(outdir, typeDir)
+			err = os.MkdirAll(fullTypeDir, 0777)
+			if err != nil {
+				log.Errorf("Failed to create type directory %s: %v", fullTypeDir, err)
+				continue
+			}
+
+			// Smart filename generation extracts meaningful names from URLs
+			// and handles collisions by appending sequence numbers
+			filename = generateSmartFilename(parsedURL, entry.Response.Content.MimeType, filenameCount)
+			fullPath = filepath.Join(fullTypeDir, filename)
+		} else {
+			// Preserve original domain structure from URLs to maintain site organization.
+			// This mode recreates the website's directory structure locally.
+			domain := parsedURL.Hostname()
+			if domain == "" {
+				domain = "unknown"
+			}
+
+			domainDir := filepath.Join(outdir, domain)
+			err = os.MkdirAll(domainDir, 0777)
+			if err != nil {
+				log.Errorf("Failed to create domain directory %s: %v", domainDir, err)
+				continue
+			}
+
+			filename = determineFilename(parsedURL, entry.Response.Content.MimeType)
+			urlPath := strings.TrimPrefix(parsedURL.Path, "/")
+			if urlPath != "" {
+				fullPath = filepath.Join(domainDir, urlPath)
+			} else {
+				fullPath = filepath.Join(domainDir, filename)
+			}
+		}
+
+		// Decode response content, handling base64 encoding for binary files.
+		// HAR format stores binary content as base64, text content as plain text.
+		content := entry.Response.Content.Text
+		var decodedContent []byte
+
+		// Check encoding type and decode accordingly
+		if entry.Response.Content.Encoding == "base64" {
+			decodedContent, err = base64.StdEncoding.DecodeString(content)
+			if err != nil {
+				log.Errorf("Failed to decode base64 content for %s: %v", entry.Request.URL, err)
+				continue
+			}
+		} else {
+			decodedContent = []byte(content)
+		}
+
+		// Write decoded content to filesystem with appropriate permissions
+		err = os.WriteFile(fullPath, decodedContent, 0644)
+		if err != nil {
+			log.Errorf("Failed to write file %s: %v", fullPath, err)
+			continue
+		}
+
+		// Record extraction details in manifest for audit trail
+		manifest = append(manifest, ManifestEntry{
+			OriginalURL: entry.Request.URL,
+			ExtractedPath: fullPath,
+			MimeType: entry.Response.Content.MimeType,
+			Size: len(decodedContent),
+			Method: entry.Request.Method,
+			Status: entry.Response.Status,
+		})
+
+		fmt.Printf("Extracted %s -> %s [%d bytes]\n", 
+			entry.Request.URL, fullPath, len(decodedContent))
+	}
+
+	// Write CSV manifest documenting all extracted files with metadata.
+	// This provides a complete audit trail of the extraction process.
+	manifestPath := filepath.Join(outdir, "extraction_manifest.csv")
+	err = writeManifest(manifest, manifestPath)
+	if err != nil {
+		log.Errorf("Failed to write manifest: %v", err)
+	} else {
+		fmt.Printf("\nExtraction manifest written to: %s\n", manifestPath)
+	}
+
+	return nil
+}
+
+// determineFilename extracts filename from URL path or generates sensible default.
+// For URLs without filenames (/, /api, etc.), creates appropriate names based on MIME type.
+// This ensures every extracted file has a meaningful, recognizable filename.
+func determineFilename(parsedURL *url.URL, mimeType string) string {
+	filename := path.Base(parsedURL.Path)
+	
+	// Generate sensible default filename for root paths or empty filenames.
+	// Maps common MIME types to conventional file extensions and names.
+	if filename == "/" || filename == "" || filename == "." {
+		switch {
+		case strings.Contains(mimeType, "text/html"):
+			filename = "index.html"
+		case strings.Contains(mimeType, "application/json"):
+			filename = "response.json"
+		case strings.Contains(mimeType, "text/css"):
+			filename = "style.css"
+		case strings.Contains(mimeType, "application/javascript"):
+			filename = "script.js"
+		case strings.Contains(mimeType, "image/"):
+			// Extract image extension from MIME type
+			if strings.Contains(mimeType, "png") {
+				filename = "image.png"
+			} else if strings.Contains(mimeType, "jpeg") {
+				filename = "image.jpg"
+			} else if strings.Contains(mimeType, "gif") {
+				filename = "image.gif"
+			} else if strings.Contains(mimeType, "svg") {
+				filename = "image.svg"
+			} else {
+				filename = "image.bin"
+			}
+		default:
+			filename = "response.bin"
+		}
+	}
+
+	return filename
+}
+
+// getTypeDirectory maps MIME types to organized directory names for sortByType mode.
+// Groups similar content types together: images/, json/, css/, javascript/, etc.
+// Provides a clean, browsable organization of extracted web assets.
+func getTypeDirectory(mimeType string) string {
+	mimeType = strings.ToLower(mimeType)
+	
+	switch {
+	case strings.Contains(mimeType, "image/"):
+		return "images"
+	case strings.Contains(mimeType, "application/json") || strings.Contains(mimeType, "text/json"):
+		return "json"
+	case strings.Contains(mimeType, "text/html"):
+		return "html"
+	case strings.Contains(mimeType, "text/css"):
+		return "css"
+	case strings.Contains(mimeType, "javascript") || strings.Contains(mimeType, "application/x-javascript"):
+		return "javascript"
+	case strings.Contains(mimeType, "font") || strings.Contains(mimeType, "woff"):
+		return "fonts"
+	case strings.Contains(mimeType, "text/"):
+		return "text"
+	case strings.Contains(mimeType, "video/"):
+		return "videos"
+	case strings.Contains(mimeType, "audio/"):
+		return "audio"
+	default:
+		return "other"
+	}
+}
+
+// generateSmartFilename creates descriptive filenames with collision handling for sortByType mode.
+// Extracts meaningful names from URL paths, falls back to content-aware defaults,
+// and appends sequence numbers to handle filename collisions across different domains.
+func generateSmartFilename(parsedURL *url.URL, mimeType string, filenameCount map[string]int) string {
+	var baseName, extension string
+	
+	// Extract base filename and extension from URL path, preserving original naming
+	urlPath := strings.TrimPrefix(parsedURL.Path, "/")
+	if urlPath != "" && urlPath != "." {
+		baseName = path.Base(urlPath)
+		if strings.Contains(baseName, ".") {
+			parts := strings.Split(baseName, ".")
+			extension = "." + parts[len(parts)-1]
+			baseName = strings.Join(parts[:len(parts)-1], ".")
+		}
+	}
+	
+	// Fallback to content-aware filename generation when URL provides no useful filename.
+	// Uses URL context clues (path segments, query params) to create descriptive names.
+	if baseName == "" || baseName == "/" {
+		switch {
+		case strings.Contains(mimeType, "application/json"):
+			if strings.Contains(parsedURL.Path, "posts") || strings.Contains(parsedURL.RawQuery, "posts") {
+				baseName = "posts"
+			} else if strings.Contains(parsedURL.Path, "api") {
+				baseName = "api_response"
+			} else {
+				baseName = "data"
+			}
+		case strings.Contains(mimeType, "text/html"):
+			baseName = "page"
+		case strings.Contains(mimeType, "image/"):
+			baseName = "image"
+		case strings.Contains(mimeType, "text/css"):
+			baseName = "style"
+		case strings.Contains(mimeType, "javascript"):
+			baseName = "script"
+		default:
+			baseName = "file"
+		}
+	}
+	
+	// Determine extension from MIME type if URL didn't provide one.
+	// Ensures files have proper extensions for system recognition.
+	if extension == "" {
+		extension = getExtensionFromMimeType(mimeType)
+	}
+	
+	// Handle filename collisions by appending sequence numbers.
+	// Tracks usage count per filename to ensure uniqueness across all extractions.
+	filename := baseName + extension
+	if count, exists := filenameCount[filename]; exists {
+		filenameCount[filename] = count + 1
+		filename = baseName + "_" + strconv.Itoa(count+1) + extension
+	} else {
+		filenameCount[filename] = 0
+	}
+	
+	return filename
+}
+
+// getExtensionFromMimeType maps MIME types to appropriate file extensions.
+// Provides comprehensive mapping for web content types to ensure proper file recognition.
+// Falls back to .bin for unknown types to prevent extension-less files.
+func getExtensionFromMimeType(mimeType string) string {
+	mimeType = strings.ToLower(mimeType)
+	
+	switch {
+	case strings.Contains(mimeType, "application/json"):
+		return ".json"
+	case strings.Contains(mimeType, "text/html"):
+		return ".html"
+	case strings.Contains(mimeType, "text/css"):
+		return ".css"
+	case strings.Contains(mimeType, "javascript"):
+		return ".js"
+	case strings.Contains(mimeType, "image/png"):
+		return ".png"
+	case strings.Contains(mimeType, "image/jpeg") || strings.Contains(mimeType, "image/jpg"):
+		return ".jpg"
+	case strings.Contains(mimeType, "image/gif"):
+		return ".gif"
+	case strings.Contains(mimeType, "image/svg"):
+		return ".svg"
+	case strings.Contains(mimeType, "image/webp"):
+		return ".webp"
+	case strings.Contains(mimeType, "text/plain"):
+		return ".txt"
+	case strings.Contains(mimeType, "application/pdf"):
+		return ".pdf"
+	case strings.Contains(mimeType, "font/woff2"):
+		return ".woff2"
+	case strings.Contains(mimeType, "font/woff"):
+		return ".woff"
+	case strings.Contains(mimeType, "font/ttf"):
+		return ".ttf"
+	default:
+		return ".bin"
+	}
+}
+
+// writeManifest creates CSV file documenting all extracted files with complete metadata.
+// Includes original URLs, extraction paths, content types, sizes, and HTTP details.
+// Provides audit trail and enables post-extraction analysis and verification.
+func writeManifest(manifest []ManifestEntry, manifestPath string) error {
+	file, err := os.Create(manifestPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write CSV header with descriptive column names for easy parsing
+	// Example row: "https://example.com/image.png","./images/image.png","image/png","1024","GET","200"
+	header := []string{"Original URL", "Extracted Path", "MIME Type", "Size (bytes)", "HTTP Method", "Status Code"}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+
+	// Write data rows with all extraction metadata for each file
+	for _, entry := range manifest {
+		record := []string{
+			entry.OriginalURL,
+			entry.ExtractedPath,
+			entry.MimeType,
+			strconv.Itoa(entry.Size),
+			entry.Method,
+			strconv.Itoa(entry.Status),
+		}
+		if err := writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,0 +1,262 @@
+package hargo
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// createTestHAR creates a minimal HAR structure for testing
+func createTestHAR() string {
+	harData := Har{
+		Log: Log{
+			Entries: []Entry{
+				{
+					Request: Request{
+						Method: "GET",
+						URL:    "https://example.com/image.png",
+					},
+					Response: Response{
+						Status: 200,
+						Content: Content{
+							MimeType: "image/png",
+							Text:     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+							Encoding: "base64",
+						},
+					},
+				},
+				{
+					Request: Request{
+						Method: "GET",
+						URL:    "https://example.com/data.json",
+					},
+					Response: Response{
+						Status: 200,
+						Content: Content{
+							MimeType: "application/json",
+							Text:     `{"test": "data"}`,
+						},
+					},
+				},
+				{
+					Request: Request{
+						Method: "GET",
+						URL:    "https://example.com/",
+					},
+					Response: Response{
+						Status: 200,
+						Content: Content{
+							MimeType: "text/html",
+							Text:     "<html><body>Test</body></html>",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, _ := json.Marshal(harData)
+	return string(jsonData)
+}
+
+// createEmptyHAR creates a HAR with no entries
+func createEmptyHAR() string {
+	harData := Har{
+		Log: Log{
+			Entries: []Entry{},
+		},
+	}
+	jsonData, _ := json.Marshal(harData)
+	return string(jsonData)
+}
+
+// cleanupExtractDirs removes any test extraction directories
+func cleanupExtractDirs() {
+	matches, _ := filepath.Glob("./hargo-extract-*")
+	for _, match := range matches {
+		os.RemoveAll(match)
+	}
+}
+
+func TestExtractWithTypeOrganization(t *testing.T) {
+	defer cleanupExtractDirs()
+
+	testHAR := createTestHAR()
+	reader := bufio.NewReader(strings.NewReader(testHAR))
+
+	err := Extract(reader, true) // sortByType = true
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	// Find the created extraction directory
+	matches, err := filepath.Glob("./hargo-extract-*")
+	if err != nil || len(matches) == 0 {
+		t.Fatal("No extraction directory created")
+	}
+
+	extractDir := matches[0]
+
+	// Verify type-based directories exist
+	imageDir := filepath.Join(extractDir, "images")
+	if _, err := os.Stat(imageDir); os.IsNotExist(err) {
+		t.Error("Images directory not created")
+	}
+
+	jsonDir := filepath.Join(extractDir, "json")
+	if _, err := os.Stat(jsonDir); os.IsNotExist(err) {
+		t.Error("JSON directory not created")
+	}
+
+	htmlDir := filepath.Join(extractDir, "html")
+	if _, err := os.Stat(htmlDir); os.IsNotExist(err) {
+		t.Error("HTML directory not created")
+	}
+
+	// Verify manifest exists
+	manifestPath := filepath.Join(extractDir, "extraction_manifest.csv")
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Error("Manifest file not created")
+	}
+}
+
+func TestExtractWithDomainOrganization(t *testing.T) {
+	defer cleanupExtractDirs()
+
+	testHAR := createTestHAR()
+	reader := bufio.NewReader(strings.NewReader(testHAR))
+
+	err := Extract(reader, false) // sortByType = false
+	if err != nil {
+		t.Fatalf("Extract failed: %v", err)
+	}
+
+	// Find the created extraction directory
+	matches, err := filepath.Glob("./hargo-extract-*")
+	if err != nil || len(matches) == 0 {
+		t.Fatal("No extraction directory created")
+	}
+
+	extractDir := matches[0]
+
+	// Verify domain-based directory exists
+	domainDir := filepath.Join(extractDir, "example.com")
+	if _, err := os.Stat(domainDir); os.IsNotExist(err) {
+		t.Error("Domain directory not created")
+	}
+
+	// Verify manifest exists
+	manifestPath := filepath.Join(extractDir, "extraction_manifest.csv")
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Error("Manifest file not created")
+	}
+}
+
+func TestExtractEmptyHAR(t *testing.T) {
+	defer cleanupExtractDirs()
+
+	emptyHAR := createEmptyHAR()
+	reader := bufio.NewReader(strings.NewReader(emptyHAR))
+
+	err := Extract(reader, false)
+	if err != nil {
+		t.Fatalf("Extract should handle empty HAR: %v", err)
+	}
+
+	// Should still create directory and manifest even with no content
+	matches, err := filepath.Glob("./hargo-extract-*")
+	if err != nil || len(matches) == 0 {
+		t.Fatal("No extraction directory created for empty HAR")
+	}
+
+	extractDir := matches[0]
+	manifestPath := filepath.Join(extractDir, "extraction_manifest.csv")
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Error("Manifest file not created for empty HAR")
+	}
+}
+
+func TestDetermineFilename(t *testing.T) {
+	tests := []struct {
+		url      string
+		mimeType string
+		expected string
+	}{
+		{"https://example.com/image.png", "image/png", "image.png"},
+		{"https://example.com/", "text/html", "index.html"},
+		{"https://example.com/api", "application/json", "api"}, // Uses URL path filename
+		{"https://example.com/style", "text/css", "style"}, // Uses URL path filename  
+		{"https://example.com/script", "application/javascript", "script"}, // Uses URL path filename
+		{"https://example.com", "text/html", "index.html"}, // Root path gets default
+	}
+
+	for _, test := range tests {
+		url := parseURL(t, test.url)
+		result := determineFilename(url, test.mimeType)
+		if result != test.expected {
+			t.Errorf("determineFilename(%s, %s) = %s, expected %s", 
+				test.url, test.mimeType, result, test.expected)
+		}
+	}
+}
+
+func TestGetTypeDirectory(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected string
+	}{
+		{"image/png", "images"},
+		{"application/json", "json"},
+		{"text/html", "html"},
+		{"text/css", "css"},
+		{"application/javascript", "javascript"},
+		{"font/woff2", "fonts"},
+		{"video/mp4", "videos"},
+		{"audio/mp3", "audio"},
+		{"unknown/type", "other"},
+	}
+
+	for _, test := range tests {
+		result := getTypeDirectory(test.mimeType)
+		if result != test.expected {
+			t.Errorf("getTypeDirectory(%s) = %s, expected %s", 
+				test.mimeType, result, test.expected)
+		}
+	}
+}
+
+func TestGetExtensionFromMimeType(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		expected string
+	}{
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"text/html", ".html"},
+		{"application/json", ".json"},
+		{"text/css", ".css"},
+		{"application/javascript", ".js"},
+		{"unknown/type", ".bin"},
+	}
+
+	for _, test := range tests {
+		result := getExtensionFromMimeType(test.mimeType)
+		if result != test.expected {
+			t.Errorf("getExtensionFromMimeType(%s) = %s, expected %s", 
+				test.mimeType, result, test.expected)
+		}
+	}
+}
+
+// Helper function to parse URL for testing
+func parseURL(t *testing.T, urlStr string) *url.URL {
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", urlStr, err)
+	}
+	return parsedURL
+}


### PR DESCRIPTION
I know this is just unprompted feature and this is total AI slop but this project was well written enough that it was super easy to whip out what I needed. My goal was to cheaply scrape some content on a site that doesn't offer an API nor takes kindly to bots/scraping and requires logging in (not trying to violate TOS). I figured I could just kind of manually click through the site and let devtools collect all the requests, save the har and process it later. I guess this is slightly grey area? my intentions are pure... I figured there had to be a har library and I found this but didn't _quite_ do what I wanted (`hargo dump` serves a different purpose upon closer inspection). So I cloned this and asked my buddy Claude to help and was able to one-shot this addition and worked fine for what I needed... Sorry for the unprompted PR - I mean no offense if hate the feature, the means by which it was authored or the code itself. Thought I'd submit this in case you or someone else deemed useful.

Thank you for your work!

- Add new 'extract' command with alias 'e' to extract response content from HAR files
- Support two organization modes: by domain (default) and by content type (--sort flag)
- Content type organization groups files into directories: images/, json/, html/, css/, javascript/, fonts/, etc.
- Smart filename generation with proper extensions based on MIME types
- Handle filename collisions with incremental naming (image_001.jpg, posts_002.json)
- Special handling for API responses (posts.json, api_response.json)
- Generate CSV manifest file mapping original URLs to extracted file paths
- Base64 decode response content when needed
- Add comprehensive VS Code debug configurations for all commands
- Update README with extract command documentation